### PR TITLE
3 non-breaking fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.1
+
+- Update http ^1.0.0
+
 ## 2.4.0
 
 - Supports Dart 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 2.4.1
+## 2.5.0
 
 - Update http ^1.0.0
 - Fix lints
+- Use http_parser instead of dart:io to support Web
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.4.1
 
 - Update http ^1.0.0
+- Fix lints
 
 ## 2.4.0
 

--- a/lib/src/azblob_base.dart
+++ b/lib/src/azblob_base.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:crypto/crypto.dart' as crypto;
+import 'package:http_parser/http_parser.dart';
 
 /// Blob type
 enum BlobType {
@@ -84,7 +84,7 @@ class AzureStorage {
   }
 
   void sign(http.Request request) {
-    request.headers['x-ms-date'] = HttpDate.format(DateTime.now());
+    request.headers['x-ms-date'] = formatHttpDate(DateTime.now());
     request.headers['x-ms-version'] = '2019-12-12';
     var ce = request.headers['Content-Encoding'] ?? '';
     var cl = request.headers['Content-Language'] ?? '';

--- a/lib/src/azblob_base.dart
+++ b/lib/src/azblob_base.dart
@@ -6,8 +6,8 @@ import 'package:crypto/crypto.dart' as crypto;
 
 /// Blob type
 enum BlobType {
-  BlockBlob,
-  AppendBlob,
+  blockBlob,
+  appendBlob,
 }
 
 /// Azure Storage Exception
@@ -15,6 +15,7 @@ class AzureStorageException implements Exception {
   final String message;
   final int statusCode;
   final Map<String, String> headers;
+
   AzureStorageException(this.message, this.statusCode, this.headers);
 }
 
@@ -23,9 +24,11 @@ class AzureStorage {
   late Map<String, String> config;
   late Uint8List accountKey;
 
-  static final String DefaultEndpointsProtocol = 'DefaultEndpointsProtocol';
-  static final String EndpointSuffix = 'EndpointSuffix';
-  static final String AccountName = 'AccountName';
+  static final String defaultEndpointsProtocol = 'DefaultEndpointsProtocol';
+  static final String endpointSuffix = 'EndpointSuffix';
+  static final String accountName = 'AccountName';
+
+  // ignore: non_constant_identifier_names
   static final String AccountKey = 'AccountKey';
 
   /// Initialize with connection string.
@@ -52,9 +55,9 @@ class AzureStorage {
   }
 
   Uri uri({String path = '/', Map<String, String>? queryParameters}) {
-    var scheme = config[DefaultEndpointsProtocol] ?? 'https';
-    var suffix = config[EndpointSuffix] ?? 'core.windows.net';
-    var name = config[AccountName];
+    var scheme = config[defaultEndpointsProtocol] ?? 'https';
+    var suffix = config[endpointSuffix] ?? 'core.windows.net';
+    var name = config[accountName];
     return Uri(
         scheme: scheme,
         host: '$name.blob.$suffix',
@@ -96,7 +99,7 @@ class AzureStorage {
     var ran = request.headers['Range'] ?? '';
     var chs = _canonicalHeaders(request.headers);
     var crs = _canonicalResources(request.url.queryParameters);
-    var name = config[AccountName];
+    var name = config[accountName];
     var path = request.url.path;
     var sig =
         '${request.method}\n$ce\n$cl\n$cz\n$cm\n$ct\n$dt\n$ims\n$imt\n$inm\n$ius\n$ran\n$chs/$name$path$crs';
@@ -135,7 +138,7 @@ class AzureStorage {
     var signedExpiry = _signedExpiry(expiry);
     var signedIdentifier = '';
     var signedVersion = '2012-02-12';
-    var name = config[AccountName];
+    var name = config[accountName];
     var canonicalizedResource = '/$name$path';
     var str = '$signedPermissions\n'
         '$signedStart\n'
@@ -162,7 +165,7 @@ class AzureStorage {
       {String? body,
       Uint8List? bodyBytes,
       String? contentType,
-      BlobType type = BlobType.BlockBlob,
+      BlobType type = BlobType.blockBlob,
       Map<String, String>? headers}) async {
     var request = http.Request('PUT', uri(path: path));
     request.headers['x-ms-blob-type'] =
@@ -173,7 +176,7 @@ class AzureStorage {
       });
     }
     if (contentType != null) request.headers['content-type'] = contentType;
-    if (type == BlobType.BlockBlob) {
+    if (type == BlobType.blockBlob) {
       if (bodyBytes != null) {
         request.bodyBytes = bodyBytes;
       } else if (body != null) {
@@ -186,7 +189,7 @@ class AzureStorage {
     var res = await request.send();
     if (res.statusCode == 201) {
       await res.stream.drain();
-      if (type == BlobType.AppendBlob && (body != null || bodyBytes != null)) {
+      if (type == BlobType.appendBlob && (body != null || bodyBytes != null)) {
         await appendBlock(path, body: body, bodyBytes: bodyBytes);
       }
       return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,14 +2,14 @@ name: azblob
 description: |
   A trivial Azure Blob Storage client.
   You can get and put Blob on server side dart.
-version: 2.4.0
+version: 2.4.1
 homepage: https://github.com/kkazuo/dart-azblob
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  http: ^0.13.6
+  http:  ^1.0.0
   crypto: ^3.0.3
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: azblob
 description: |
   A trivial Azure Blob Storage client.
   You can get and put Blob on server side dart.
-version: 2.4.1
+version: 2.5.0
 homepage: https://github.com/kkazuo/dart-azblob
 
 environment:
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   http:  ^1.0.0
+  http_parser: ^4.0.0
   crypto: ^3.0.3
 
 dev_dependencies:

--- a/test/azblob_test.dart
+++ b/test/azblob_test.dart
@@ -1,11 +1,12 @@
+import 'dart:io' as dart_io;
+import 'package:http_parser/http_parser.dart' as http_parser;
 import 'package:test/test.dart';
 
 void main() {
-  group('A group of tests', () {
-    setUp(() {});
-
-    test('First Test', () {
-      expect(true, isTrue);
-    });
+  test('Http Date format', () {
+    final date = DateTime.now();
+    final dartIoString = dart_io.HttpDate.format(date);
+    final httpParserString = http_parser.formatHttpDate(date);
+    expect(dartIoString, httpParserString);
   });
 }


### PR DESCRIPTION
- Update http ^1.0.0 
- Fix lints `constant_identifier_names`, `non_constant_identifier_names`
- Use http_parser instead of dart:io to support Web
> /// Return a HTTP-formatted string representation of [date].
///
/// This follows [RFC 822](http://tools.ietf.org/html/rfc822) as updated by
/// [RFC 1123](http://tools.ietf.org/html/rfc1123).
String formatHttpDate(DateTime date)
